### PR TITLE
[WO-584] Return escaped plaintext filenames

### DIFF
--- a/src/mimefuncs.js
+++ b/src/mimefuncs.js
@@ -647,7 +647,7 @@
                 if (encodedStr.length <= maxLength) {
                     return [{
                         key: key,
-                        value: encodedStr
+                        value: /[\s";=]/.test(encodedStr) ? '"' + encodedStr + '"' : encodedStr
                     }];
                 }
 
@@ -736,7 +736,7 @@
                     // unencoded lines: {name}*{part}
                     // if any line needs to be encoded then the first line (part==0) is always encoded
                     key: key + '*' + i + (item.encoded ? '*' : ''),
-                    value: item.line
+                    value: /[\s";=]/.test(item.line) ? '"' + item.line + '"' : item.line
                 };
             });
         },

--- a/test/mimefuncs-unit.js
+++ b/test/mimefuncs-unit.js
@@ -263,23 +263,23 @@ define(['chai', '../src/mimefuncs'], function(chai, mimefuncs) {
         });
 
         describe('#continuationEncode', function() {
-            it('should return unmodified', function() {
+            it('should return quoted', function() {
                 expect([{
                     key: 'title',
-                    value: 'this is just a title'
+                    value: '"this is just a title"'
                 }]).to.deep.equal(mimefuncs.continuationEncode('title', 'this is just a title', 500));
             });
 
             it('should encode and split ascii', function() {
                 expect([{
                     key: 'title*0',
-                    value: 'this '
+                    value: '"this "'
                 }, {
                     key: 'title*1',
-                    value: 'is ju'
+                    value: '"is ju"'
                 }, {
                     key: 'title*2',
-                    value: 'st a '
+                    value: '"st a "'
                 }, {
                     key: 'title*3',
                     value: 'title'
@@ -292,7 +292,7 @@ define(['chai', '../src/mimefuncs'], function(chai, mimefuncs) {
                     value: 'utf-8\'\'this%20is%20'
                 }, {
                     key: 'title*1',
-                    value: 'just a title '
+                    value: '"just a title "'
                 }, {
                     key: 'title*2*',
                     value: '%C3%B5%C3%A4%C3%B6'


### PR DESCRIPTION
If filename is continuation encoded but is actually plaintext, then return the value inside quotes (mailbuild does not put the quotes automatically anymore)
