### PR TITLE
fromTypedArray lives under mimefuncs, not mimefuncs.charset

### DIFF
--- a/src/mimefuncs.js
+++ b/src/mimefuncs.js
@@ -979,7 +979,7 @@
             try {
                 return new TextDecoder(fromCharset).decode(buf);
             } catch (E) {
-                return this.fromTypedArray(buf);
+                return mimefuncs.fromTypedArray(buf);
             }
 
         },

--- a/test/mimefuncs-unit.js
+++ b/test/mimefuncs-unit.js
@@ -540,6 +540,19 @@ define(['chai', '../src/mimefuncs'], function(chai, mimefuncs) {
 
                     expect(str).to.deep.equal(mimefuncs.charset.decode(encoded, encoding));
                 });
+
+                // Note: This is being added as a test to make sure that the
+                // call to fromArray succeeds.  It is possible that the right
+                // course of action is actually to try decoding with a series
+                // of fallback charsets before doing a binary conversion.
+                it('should fall back to binary conversion for illegal charset', function() {
+                    var str = 'a1\x80\xff';
+                    var encoded = [0x61, 0x31, 0x80, 0xff];
+                    // the motivating real-world instance that caused this was
+                    // 'x-unknown'.
+                    var encoding = 'x-illegal';
+                    expect(str).to.deep.equal(mimefuncs.charset.decode(encoded, encoding));
+                });
             });
 
             describe('#convert', function() {


### PR DESCRIPTION
For the Yandex IMAP server, for messages without a specific charset, the server
returns a charset of "X-UNKNOWN" which was causing the mimefuncs.charset.decode
function to end up in its catch() clause where "this.fromTypedArray" was
throwing.

There are arguably better things that can be done in the case of x-unknown like
trying as utf-8 and then an ISO-8859-x variant.  Or just the iso-8859-x variant
first.  (Roundcube used ISO-8859-15 for at least a while, see
http://trac.roundcube.net/changeset/38b012e0/github).  But for this commit the
main point is just to properly call fromTypedArray per original intent.

Here's the example BODYSTRUCTURE for an example message:

```
("text" "plain" (CHARSET "X-UNKNOWN") NIL NIL "7bit" 29 1 NIL NIL NIL NIL)
```

Resulting from the following key headers:

```
Content-Transfer-Encoding: 7bit
Content-Type: text/plain
```

If creating a test Yandex account, be aware that the default message injected
into the INBOX is very minimal and the IMAP server produces a similar (but
completely incorrect) bodystructure.  (The message is multipart/alternative
with a text/plain and text/html but is just reported as text/plain at the top
level.)
