### PR TITLE
fix package name in global insertion

### DIFF
--- a/src/emailjs-mime-codec.js
+++ b/src/emailjs-mime-codec.js
@@ -41,7 +41,7 @@
         });
     } else {
         // global for browser
-        root['emailjs-mimecodec'] = factory(root.TextEncoder, root.TextDecoder, root.btoa);
+        root['emailjs-mime-codec'] = factory(root.TextEncoder, root.TextDecoder, root.btoa);
     }
 }(this, function(TextEncoder, TextDecoder, btoa) {
     'use strict';


### PR DESCRIPTION
The proper package name of this package is 'emailjs-mime-codec', not
'emails-mimecodec' — note that extra hyphen. This misspelling breaks
loading 'emailjs-mime-parser' without 'amd' or something similar.