### PR TITLE
Unicode characters like 4-byte emojis caused errors when used in attachment filenames

### DIFF
--- a/src/mimecodec-unit.js
+++ b/src/mimecodec-unit.js
@@ -350,10 +350,10 @@ describe('#continuationEncode', function () {
   it('should encode and split unicode', function () {
     expect([{
       key: 'title*0*',
-      value: 'utf-8\'\'this%20is%20'
+      value: 'utf-8\'\'this%20is%20j'
     }, {
-      key: 'title*1',
-      value: '"just a title "'
+      key: 'title*1*',
+      value: 'ust%20a%20title%20'
     }, {
       key: 'title*2*',
       value: '%C3%B5%C3%A4%C3%B6'
@@ -370,6 +370,13 @@ describe('#continuationEncode', function () {
     }).join('; ')
     var parsedHeader = parseHeaderValue(headerLine)
     expect(input).to.equal(mimeWordsDecode(parsedHeader.params.filename))
+  })
+
+  it('should not cause URIError when encoding multi-byte unicode chars', function () {
+    expect([{
+      key: 'title*0*',
+      value: 'utf-8\'\'%F0%9F%98%8A'
+    }]).to.deep.equal(continuationEncode('title', '😊', 500))
   })
 })
 

--- a/src/mimecodec.js
+++ b/src/mimecodec.js
@@ -475,8 +475,6 @@ export function continuationEncode (key, data, maxLength, fromCharset) {
   const list = []
   var encodedStr = typeof data === 'string' ? data : decode(data, fromCharset)
   var line
-  var startPos = 0
-  var isEncoded = false
 
   maxLength = maxLength || 50
 
@@ -503,66 +501,26 @@ export function continuationEncode (key, data, maxLength, fromCharset) {
       })
     }
   } else {
-    // first line includes the charset and language info and needs to be encoded
-    // even if it does not contain any unicode characters
-    line = 'utf-8\'\''
-    isEncoded = true
-    startPos = 0
     // process text with unicode or special chars
-    for (var i = 0, len = encodedStr.length; i < len; i++) {
-      let chr = encodedStr[i]
-
-      if (isEncoded) {
-        chr = encodeURIComponent(chr)
-      } else {
-        // try to urlencode current char
-        chr = chr === ' ' ? chr : encodeURIComponent(chr)
-        // By default it is not required to encode a line, the need
-        // only appears when the string contains unicode or special chars
-        // in this case we start processing the line over and encode all chars
-        if (chr !== encodedStr[i]) {
-          // Check if it is even possible to add the encoded char to the line
-          // If not, there is no reason to use this line, just push it to the list
-          // and start a new line with the char that needs encoding
-          if ((encodeURIComponent(line) + chr).length >= maxLength) {
-            list.push({
-              line: line,
-              encoded: isEncoded
-            })
-            line = ''
-            startPos = i - 1
-          } else {
-            isEncoded = true
-            i = startPos
-            line = ''
-            continue
-          }
-        }
+    const uriEncoded = encodeURIComponent('utf-8\'\'' + encodedStr)
+    let i = 0
+    while (true) {
+      let len = maxLength
+      // must not split hex encoded byte between lines
+      if (uriEncoded[i + maxLength - 1] === '%') {
+        len -= 1
+      } else if (uriEncoded[i + maxLength - 2] === '%') {
+        len -= 2
       }
-
-      // if the line is already too long, push it to the list and start a new one
-      if ((line + chr).length >= maxLength) {
-        list.push({
-          line: line,
-          encoded: isEncoded
-        })
-        line = chr = encodedStr[i] === ' ' ? ' ' : encodeURIComponent(encodedStr[i])
-        if (chr === encodedStr[i]) {
-          isEncoded = false
-          startPos = i - 1
-        } else {
-          isEncoded = true
-        }
-      } else {
-        line += chr
+      line = uriEncoded.substr(i, len)
+      if (!line) {
+        break
       }
-    }
-
-    if (line) {
       list.push({
         line: line,
-        encoded: isEncoded
+        encoded: true
       })
+      i += line.length
     }
   }
 


### PR DESCRIPTION
How to reproduce:
Create a mail with attachment that has smiley in its name (e.g. Emoji-😊.png)
Try to build the mail using emailjs-mime-builder.

Observe error:
URIError: URI malformed at encodeURIComponent.

Happens when trying to encode individual bytes from emoji's 4 bytes.